### PR TITLE
feat(WEB-30): improve Playwright .gitignore patterns for Turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,26 @@ node_modules
 # Testing
 coverage
 
-# Playwright
-test-results/
-playwright-report/
-playwright/.auth/
+# Playwright - Turborepo monorepo patterns
+# Core Playwright generated files
+**/test-results/
+**/playwright-report/
+**/playwright/.auth/
+**/blob-report/
+**/html-report/
+
+# Playwright specific artifacts
+**/*.trace
+**/test-results/**/*.zip
+**/playwright-report/**/*.zip
+**/test-results.json
+**/.pwtest-global/
+**/global-setup-*.json
+
+# Browser downloads and artifacts
+**/downloads/
+**/videos/
+**/screenshots/
 
 # Turbo
 .turbo
@@ -51,5 +67,3 @@ npm-debug.log*
 
 # IDE
 .vscode
-# Playwright
-apps/web/test-results/


### PR DESCRIPTION
## Summary
- Add comprehensive monorepo-aware Playwright patterns using `**/` syntax for all apps
- Include test-results, playwright-report, .auth directories across monorepo
- Add browser artifacts: traces, videos, screenshots, downloads
- Remove duplicate and redundant entries
- Centralize patterns in root .gitignore per Turborepo best practices

## Changes Made
- Updated root `.gitignore` with comprehensive Playwright patterns
- Used `**/` patterns to cover all apps in monorepo structure
- Removed duplicate entries and consolidated patterns
- Added comments for better organization

## Test Plan
- [x] Verified patterns work across monorepo structure
- [x] Confirmed no Playwright artifacts are tracked in git
- [x] Followed Turborepo conventions for centralized gitignore

Resolves Linear issue: WEB-30

🤖 Generated with [Claude Code](https://claude.ai/code)