### PR TITLE
feat: skip claude-review for WIP commits (#19)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Always run EXCEPT if the PR title or latest commit message contains 'wip' (case-insensitive)
+    if: |
+      !contains(lower(github.event.pull_request.title), 'wip') &&
+      !contains(lower(github.event.pull_request.head.commit.message), 'wip')
     
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Modified GitHub Actions workflow to exclude PRs with 'wip' in title or commit message
- Claude review will now run on all PRs except those marked as WIP
- Uses case-insensitive matching for better flexibility

## Changes Made

- Updated `.github/workflows/claude-code-review.yml` to add conditional logic
- Added `if` condition that excludes PRs when title or commit message contains 'wip' (case-insensitive)
- Maintains all existing functionality while providing opt-out mechanism

## Testing

The conditional logic will be tested when:
- ✅ Regular PRs (without 'wip') should trigger claude-review  
- ❌ PRs with 'wip', 'WIP', or 'Wip' in title should skip claude-review
- ❌ PRs with 'wip' in latest commit message should skip claude-review

## Resolves

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)